### PR TITLE
Fix cchardet build failing on Python versions later than version 3.9

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,8 @@ setuptools.setup(
         ],
     },
     install_requires=[
-        'cchardet',
+        'cchardet;python_version<\'3.10\'',
+        'faust-cchardet;python_version>=\'3.10\''
         'pysubs2',
         'PyQt5'
     ],

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setuptools.setup(
     },
     install_requires=[
         'cchardet;python_version<\'3.10\'',
-        'faust-cchardet;python_version>=\'3.10\''
+        'faust-cchardet;python_version>=\'3.10\'',
         'pysubs2',
         'PyQt5'
     ],


### PR DESCRIPTION
As the title suggests, cchardet is failing to build on Python versions later than 3.9 due to it being unmaintained. In order to fix this, I made it, so it uses [faust-cchardet](https://github.com/faust-streaming/cChardet) if a Python version later than 3.9 is being used.

Once faust-cchardet has proven to be reliable, we can drop the version check entirely and exclusively use it instead.